### PR TITLE
Add simple Python HTTP server

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,19 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class HelloHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(b'Hello, World!\n')
+
+
+def run(server_class=HTTPServer, handler_class=HelloHandler):
+    server_address = ('0.0.0.0', 8000)
+    httpd = server_class(server_address, handler_class)
+    print(f'Serving on http://{server_address[0]}:{server_address[1]}')
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add lightweight HTTP server that returns a plain text Hello World response

## Testing
- `python -m py_compile app.py`
- `python app.py & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_689e548a35e4832798eb0b3131eecdd4